### PR TITLE
Fixes #5 with camelCased module names and templateUrl

### DIFF
--- a/module/templates/_module.js
+++ b/module/templates/_module.js
@@ -1,12 +1,12 @@
 (function(app) {
 
     app.config(['$stateProvider', function ($stateProvider) {
-        $stateProvider.state('<%= name %>', {
+        $stateProvider.state('<%= camelModuleName %>', {
             url: '/<%= lowerModuleName %>',
             views: {
                 "main": {
                     controller: '<%= capitalModuleName %>Controller',
-                    templateUrl: '<%= name %>/<%= name %>.tpl.html'
+                    templateUrl: '<%= camelModuleName %>/<%= camelModuleName %>.tpl.html'
                 }
             },
             data:{ pageTitle: '<%= capitalModuleName %>' }


### PR DESCRIPTION
Fixes #5 where camelCased module names don't wire up in the templateUrl correctly because the use the name variable instead of the camelModuleName
