### PR TITLE
jshint: 'globals' key is a property of options.

### DIFF
--- a/app/templates/root/_Gruntfile.js
+++ b/app/templates/root/_Gruntfile.js
@@ -334,9 +334,9 @@ module.exports = function(grunt) {
                 noarg: true,
                 sub: true,
                 boss: true,
-                eqnull: true
+                eqnull: true,
+                globals: {}
             },
-            globals: {}
         },
 
         /**


### PR DESCRIPTION
This was causing another jshint task to be created, called 'globals' that lints 0 files.