### PR TITLE
Fix vendor css link in compiled version

### DIFF
--- a/app/templates/root/_Gruntfile.js
+++ b/app/templates/root/_Gruntfile.js
@@ -437,7 +437,6 @@ module.exports = function(grunt) {
                 dir: '<%%= compile_dir %>',
                 src: [
                     '<%%= concat.compile_js.dest %>',
-                    '<%%= vendor_files.css %>',
                     '<%%= build_dir %>/assets/<%%= pkg.name %>-<%%= pkg.version %>.css'
                 ]
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ngbp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Yeoman generator based on the ngBoilerplate kickstarter, a best-practice boilerplate for scalable Angular projects built on a highly modular, folder-by-feature structure. Now with easily switchable mocking via $httpBackend and RESTful resource scaffolding.",
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
As it currently stands, the `compile` task adds an erroneous stylesheet link for each vendor css; even though the css files are included in the bundled css file.

The generator still works, but the PR eliminates that link and removes the console error(s) saying that the vendor css files can't be found
